### PR TITLE
Renaming UserInformation. the name was too generic and I could repres…

### DIFF
--- a/FitGoal/FitGoal.xcodeproj/project.pbxproj
+++ b/FitGoal/FitGoal.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		05012CA3240D21F00065E560 /* Roboto-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 05012CA0240D1FD70065E560 /* Roboto-Light.ttf */; };
 		05012CA4240D21F30065E560 /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 05012C9E240D1FD70065E560 /* Roboto-Regular.ttf */; };
 		050507ED24315B3800CE58BC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 050507EC24315B3800CE58BC /* GoogleService-Info.plist */; };
-		050507F52431C54400CE58BC /* UserInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050507F42431C54400CE58BC /* UserInformation.swift */; };
+		050507F52431C54400CE58BC /* UserIdentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050507F42431C54400CE58BC /* UserIdentification.swift */; };
 		050DC1272411FED9009BF1E5 /* RoutineSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050DC1262411FED9009BF1E5 /* RoutineSectionHeader.swift */; };
 		0515518524501266001A72AA /* WalkthroughIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0515518224501266001A72AA /* WalkthroughIconView.swift */; };
 		0515518624501266001A72AA /* WalkthroughIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0515518324501266001A72AA /* WalkthroughIcon.swift */; };
@@ -99,7 +99,7 @@
 		05012C9F240D1FD70065E560 /* Roboto-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		05012CA0240D1FD70065E560 /* Roboto-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Light.ttf"; sourceTree = "<group>"; };
 		050507EC24315B3800CE58BC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		050507F42431C54400CE58BC /* UserInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformation.swift; sourceTree = "<group>"; };
+		050507F42431C54400CE58BC /* UserIdentification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentification.swift; sourceTree = "<group>"; };
 		050DC1262411FED9009BF1E5 /* RoutineSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSectionHeader.swift; sourceTree = "<group>"; };
 		0515518224501266001A72AA /* WalkthroughIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkthroughIconView.swift; sourceTree = "<group>"; };
 		0515518324501266001A72AA /* WalkthroughIcon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkthroughIcon.swift; sourceTree = "<group>"; };
@@ -240,7 +240,7 @@
 		0517AD52242442F20049E48B /* Singup&Singin */ = {
 			isa = PBXGroup;
 			children = (
-				050507F42431C54400CE58BC /* UserInformation.swift */,
+				050507F42431C54400CE58BC /* UserIdentification.swift */,
 				054DC8AA2434602C008B2B4F /* AppPreferences.swift */,
 				054DC8A824344CDA008B2B4F /* Authenticator.swift */,
 				05EB1B3D242473D400E7984B /* SignUpViewController.swift */,
@@ -705,7 +705,7 @@
 				054DC8AB2434602C008B2B4F /* AppPreferences.swift in Sources */,
 				058312A9242C291900708195 /* AuthenticationType.swift in Sources */,
 				053E78A82455472B00A8CF37 /* UserProfileConfiguratorViewController.swift in Sources */,
-				050507F52431C54400CE58BC /* UserInformation.swift in Sources */,
+				050507F52431C54400CE58BC /* UserIdentification.swift in Sources */,
 				F14233AD240CF77D000E8873 /* SceneDelegate.swift in Sources */,
 				053E78A6245538B700A8CF37 /* WalkthroughPageViewController.swift in Sources */,
 				0517AD5624244DD40049E48B /* GreetingViewController.swift in Sources */,

--- a/FitGoal/FitGoal/Singup&Singin/AppPreferences.swift
+++ b/FitGoal/FitGoal/Singup&Singin/AppPreferences.swift
@@ -11,11 +11,11 @@ class AppPreferences {
     
     private let defaults = UserDefaults.standard
     
-    var loggedInUser: UserInformation? {
+    var loggedInUser: UserIdentification? {
         get {
             guard let name = defaults.string(forKey: UsersInfoKey.name.rawValue) else { return nil }
             guard let email = defaults.string(forKey: UsersInfoKey.email.rawValue) else { return nil }
-            return UserInformation(name: name, email: email)
+            return UserIdentification(name: name, email: email)
         }
         set(userInfo) {
             if let userInfo = userInfo {

--- a/FitGoal/FitGoal/Singup&Singin/Authenticator.swift
+++ b/FitGoal/FitGoal/Singup&Singin/Authenticator.swift
@@ -14,7 +14,7 @@ import FBSDKLoginKit
 class Authenticator: NSObject, GIDSignInDelegate {
     
     typealias SignInCallback = (Result<Void, Error>) -> Void
-    typealias UserInfoCallback = (Result<UserInformation, Error>) -> Void
+    typealias UserInfoCallback = (Result<UserIdentification, Error>) -> Void
     
     private let appPreferences = AppPreferences()
     
@@ -34,7 +34,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
     }
     
     func authenticate(sender: UIViewController, completion: @escaping SignInCallback) {
-        func persistIfPossible(userInfoResult: Result<UserInformation, Error>) {
+        func persistIfPossible(userInfoResult: Result<UserIdentification, Error>) {
             switch userInfoResult {
             case .success(let userInfo):
                 appPreferences.loggedInUser = userInfo
@@ -165,7 +165,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
                 return
             }
             
-            completion(.success(UserInformation(name: name, email: email)))
+            completion(.success(UserIdentification(name: name, email: email)))
         }
     }
     
@@ -179,7 +179,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
                 case .facebook, .twitter, .google:
                     self.parseUserInformation(from: dataResults, error: error, completion: completion)
                 case .custom(_, let email, let name):
-                    completion(.success(UserInformation(name: name, email: email)))
+                    completion(.success(UserIdentification(name: name, email: email)))
                 }
             }
         }

--- a/FitGoal/FitGoal/Singup&Singin/Authenticator.swift
+++ b/FitGoal/FitGoal/Singup&Singin/Authenticator.swift
@@ -14,11 +14,11 @@ import FBSDKLoginKit
 class Authenticator: NSObject, GIDSignInDelegate {
     
     typealias SignInCallback = (Result<Void, Error>) -> Void
-    typealias UserInfoCallback = (Result<UserIdentification, Error>) -> Void
+    typealias UserIdentificationCallback = (Result<UserIdentification, Error>) -> Void
     
     private let appPreferences = AppPreferences()
     
-    private var userInfoCallback: UserInfoCallback?
+    private var userIdentificationCallback: UserIdentificationCallback?
     
     private var authenticationMethod: AuthenticationMethod
     
@@ -34,10 +34,10 @@ class Authenticator: NSObject, GIDSignInDelegate {
     }
     
     func authenticate(sender: UIViewController, completion: @escaping SignInCallback) {
-        func persistIfPossible(userInfoResult: Result<UserIdentification, Error>) {
-            switch userInfoResult {
-            case .success(let userInfo):
-                appPreferences.loggedInUser = userInfo
+        func persistIfPossible(userIdentificationResult: Result<UserIdentification, Error>) {
+            switch userIdentificationResult {
+            case .success(let userIdentification):
+                appPreferences.loggedInUser = userIdentification
                 completion(.success(()))
             case .failure(let error):
                 completion(.failure(error))
@@ -46,19 +46,19 @@ class Authenticator: NSObject, GIDSignInDelegate {
         
         switch authenticationMethod {
         case .custom(let customAuth):
-            customSignIn(customAuth: customAuth, completion: persistIfPossible(userInfoResult:))
+            customSignIn(customAuth: customAuth, completion: persistIfPossible(userIdentificationResult:))
         case .socialMedia(let socialMedia):
-            authenticate(with: socialMedia, sender: sender, completion: persistIfPossible(userInfoResult:))
+            authenticate(with: socialMedia, sender: sender, completion: persistIfPossible(userIdentificationResult:))
         }
     }
     
-    private func googleSignIn(sender: UIViewController, completion: @escaping UserInfoCallback) {
-        self.userInfoCallback = completion
+    private func googleSignIn(sender: UIViewController, completion: @escaping UserIdentificationCallback) {
+        self.userIdentificationCallback = completion
         GIDSignIn.sharedInstance()?.presentingViewController = sender
         GIDSignIn.sharedInstance()?.signIn()
     }
     
-    private func facebookSignIn(sender: UIViewController, completion: @escaping UserInfoCallback) {
+    private func facebookSignIn(sender: UIViewController, completion: @escaping UserIdentificationCallback) {
         let permissions = ["public_profile", "email"]
         
         LoginManager().logIn(permissions: permissions, from: sender) { (loginResults, error) in
@@ -82,7 +82,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    private func twitterSignIn(sender: UIViewController, completion: @escaping UserInfoCallback) {
+    private func twitterSignIn(sender: UIViewController, completion: @escaping UserIdentificationCallback) {
         twitterProvider.getCredentialWith(nil) { (credentials, error) in
             if let error = error {
                 completion(.failure(error))
@@ -96,7 +96,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    private func customSignIn(customAuth: CustomAuthentication, completion: @escaping UserInfoCallback) {
+    private func customSignIn(customAuth: CustomAuthentication, completion: @escaping UserIdentificationCallback) {
         let email = customAuth.email
         let userName = customAuth.name
         let password = customAuth.password
@@ -118,15 +118,15 @@ class Authenticator: NSObject, GIDSignInDelegate {
     // MARK: -Google Delegate
     func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
         if let error = error {
-            userInfoCallback?(.failure(error))
+            userIdentificationCallback?(.failure(error))
         } else {
             guard let authentication = user.authentication else {
-                userInfoCallback?(.failure(MissingUserInfoError.noAuthenticationObjectFound))
+                userIdentificationCallback?(.failure(MissingUserIdentifierError.noAuthenticationObjectFound))
                 return
             }
             
-            guard let callback = userInfoCallback else {
-                assertionFailure("nil userInfoCallback")
+            guard let callback = userIdentificationCallback else {
+                assertionFailure("nil userIdentificationCallback")
                 return
             }
             self.authenticateUser(with: .google(accessToken: authentication.accessToken, tokenID: authentication.idToken), completion: callback)
@@ -135,7 +135,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
     
     //MARK: - Helper functions
     
-    private func authenticate(with socialMedia: SocialMedia, sender: UIViewController, completion: @escaping UserInfoCallback) {
+    private func authenticate(with socialMedia: SocialMedia, sender: UIViewController, completion: @escaping UserIdentificationCallback) {
         switch socialMedia {
         case .facebook:
             facebookSignIn(sender: sender, completion: completion)
@@ -146,22 +146,22 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    private func parseUserInformation(from dataResults: AuthDataResult?, error: Error?, completion: UserInfoCallback) {
+    private func parseUserIdentifiers(from dataResults: AuthDataResult?, error: Error?, completion: UserIdentificationCallback) {
         if let error = error {
             completion(.failure(error))
         } else {
             guard let user = dataResults?.user else {
-                completion(.failure(MissingUserInfoError.noUserFound))
+                completion(.failure(MissingUserIdentifierError.noUserFound))
                 return
             }
             
             guard let name = user.displayName else {
-                completion(.failure(MissingUserInfoError.noNameFound))
+                completion(.failure(MissingUserIdentifierError.noNameFound))
                 return
             }
             
             guard let email = user.email else {
-                completion(.failure(MissingUserInfoError.noEmailFound))
+                completion(.failure(MissingUserIdentifierError.noEmailFound))
                 return
             }
             
@@ -169,7 +169,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    fileprivate func authenticateUser(with providerSpecifications: ProviderSpecifications, completion: @escaping UserInfoCallback) {
+    fileprivate func authenticateUser(with providerSpecifications: ProviderSpecifications, completion: @escaping UserIdentificationCallback) {
         let credentials = providerSpecifications.credentials
         Auth.auth().signIn(with: credentials) { (dataResults, error) in
             if let error = error {
@@ -177,7 +177,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
             } else {
                 switch providerSpecifications {
                 case .facebook, .twitter, .google:
-                    self.parseUserInformation(from: dataResults, error: error, completion: completion)
+                    self.parseUserIdentifiers(from: dataResults, error: error, completion: completion)
                 case .custom(_, let email, let name):
                     completion(.success(UserIdentification(name: name, email: email)))
                 }
@@ -185,7 +185,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    private func handleLoginError(error: Error, providerSpecifications: ProviderSpecifications, completion: @escaping UserInfoCallback) {
+    private func handleLoginError(error: Error, providerSpecifications: ProviderSpecifications, completion: @escaping UserIdentificationCallback) {
         let nsError = error as NSError
         if nsError.code == AuthErrorCode.accountExistsWithDifferentCredential.rawValue {
             self.handleAccountExistsWithDifferentCredentials(
@@ -204,7 +204,7 @@ class Authenticator: NSObject, GIDSignInDelegate {
         }
     }
     
-    private func handleAccountExistsWithDifferentCredentials(error: NSError, providerSpecifications: ProviderSpecifications, completion: @escaping UserInfoCallback) {
+    private func handleAccountExistsWithDifferentCredentials(error: NSError, providerSpecifications: ProviderSpecifications, completion: @escaping UserIdentificationCallback) {
         guard let email = error.userInfo[AuthErrorUserInfoEmailKey] as? String else {
             completion(.failure(error))
             return
@@ -255,7 +255,7 @@ struct CustomAuthentication {
     let password: String
 }
 
-private enum MissingUserInfoError: Error {
+private enum MissingUserIdentifierError: Error {
     case noUserFound
     case noNameFound
     case noEmailFound

--- a/FitGoal/FitGoal/Singup&Singin/UserIdentification.swift
+++ b/FitGoal/FitGoal/Singup&Singin/UserIdentification.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UserInformation {
+struct UserIdentification {
     let name: String
     let email: String
 }


### PR DESCRIPTION
I'll start making smaller PRs.

This PR is a renaming: `UserInformation` is now `UserIdentification`.
The reason for this change is that the old name was too generic and I could use it to describe other parts of my code, so I think it was a bad name. So because name and email are recognised as personal identifiers, I think this is a clearer name.
Enjoy
